### PR TITLE
DocuSignClient.get_envelope_document() returns a file-like object with close() method

### DIFF
--- a/pydocusign/client.py
+++ b/pydocusign/client.py
@@ -243,4 +243,5 @@ class DocuSignClient(object):
                       documentId=documentId)
         headers = self.base_headers()
         response = requests.get(url, headers=headers, stream=True)
+        setattr(response.raw, 'close', response.close)
         return response.raw


### PR DESCRIPTION
Refs #12
