### PR TITLE
Support tox 2

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     mock
     nose
     rednose
+passenv = DOCUSIGN_*
 commands =
     pip install -e .
     nosetests --with-doctest --no-path-adjustment --nocapture --with-coverage --cover-package=pydocusign --all-modules --rednose --verbosity=2  {posargs:pydocusign tests}


### PR DESCRIPTION
Tox 2 does not pass all env vars anymore. We must define which env vars are passed to tests.

http://tox.readthedocs.org/en/latest/config.html#confval-passenv=SPACE-SEPARATED-GLOBNAMES