### PR TITLE
python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 env:
   matrix:
   - TOXENV=py27
+  - TOXENV=py33
+  - TOXENV=py34
+  - TOXENV=py35
   - TOXENV=flake8
   - TOXENV=readme
 install:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ about future releases, check `milestones`_ and :doc:`/about/vision`.
 0.13.3 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add support of python3.
 
 
 0.13.2 (2015-09-10)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -46,7 +46,7 @@ Clone `pydocusign` repository (adapt to use your own fork):
 
 .. code:: sh
 
-   git clone git@github.com:novapost/pydocusign.git
+   git clone git@github.com:novafloss/pydocusign.git
    cd pydocusign/
 
 

--- a/README.rst
+++ b/README.rst
@@ -28,6 +28,6 @@ Resources
 * Changelog: https://pydocusign.readthedocs.org/en/latest/about/changelog.html
 * Roadmap: https://github.com/novafloss/pydocusign/milestones
 * Code repository: https://github.com/novafloss/pydocusign
-* Continuous integration: https://travis-ci.org/novapost/pydocusign
+* Continuous integration: https://travis-ci.org/novafloss/pydocusign
 
 .. _`DocuSign`: https://www.docusign.com

--- a/demo/accounts.py
+++ b/demo/accounts.py
@@ -9,6 +9,11 @@ import os
 
 import pydocusign
 
+try:
+    raw_input
+except NameError:
+    raw_input = input
+
 
 def prompt(environ_key, description, default):
     try:
@@ -55,6 +60,18 @@ signer_return_url = prompt(
     'DOCUSIGN_TEST_SIGNER_RETURN_URL',
     'Signer return URL',
     '')
+account_email = prompt(
+    'DOCUSIGN_TEST_ACCOUNT_EMAIL',
+    'Subsidiary account email',
+    '')
+account_password = prompt(
+    'DOCUSIGN_TEST_ACCOUNT_PASSWORD',
+    'Subsidiary account password',
+    '')
+plan_id = prompt(
+    'DOCUSIGN_TEST_PLAN_ID',
+    'DocuSign Plan ID',
+    '')
 
 
 # Create a client.
@@ -80,13 +97,11 @@ print("   Received data: {data}".format(data=account_information))
 
 # Create a subsidiary account.
 print("3. POST /accounts")
-account_email = "benoit.bryon+pydocusign-test@novapost.fr"
-account_password = "notasecret"
 account_input = {
     "accountName": "Pydocusign Test Account",
     "accountSettings": [],
     "addressInformation": {
-        "address1": "32 rue de Paradis",
+        "address1": "Somewhere",
         "address2": "",
         "city": "Paris",
         "country": "France",
@@ -110,7 +125,7 @@ account_input = {
         "userSettings": [],
     },
     "planInformation": {
-        "planId": "64c9f146-91d8-4137-8367-fd3f3a23ef76",
+        "planId": plan_id,
     },
     "referralInformation": None,
     "socialAccountInformation": None,

--- a/demo/embeddedsigning.py
+++ b/demo/embeddedsigning.py
@@ -6,12 +6,17 @@ See also http://iodocs.docusign.com/APIWalkthrough/embeddedSigning
 
 """
 from __future__ import print_function
+import hashlib
 import os
-import sha
 import uuid
 
 import pydocusign
 from pydocusign.test import fixtures_dir
+
+try:
+    raw_input
+except NameError:
+    raw_input = input
 
 
 def prompt(environ_key, description, default):
@@ -137,11 +142,11 @@ print("   Received UserId for recipient 1: {0}".format(
 # Retrieve embedded signing for first recipient.
 print("4. Get DocuSign Recipient View")
 signing_url = envelope.post_recipient_view(
-    routingOrder=1,
+    envelope.recipients[0],
     returnUrl=signer_return_url)
 print("   Received signing URL for recipient 0: {0}".format(signing_url))
 signing_url = envelope.post_recipient_view(
-    routingOrder=2,
+    envelope.recipients[1],
     returnUrl=signer_return_url)
 print("   Received signing URL for recipient 1: {0}".format(signing_url))
 
@@ -152,11 +157,9 @@ document_list = envelope.get_document_list()
 print("   Received document list: {0}".format(document_list))
 print("6. Download document from DocuSign.")
 document = envelope.get_document(document_list[0]['documentId'])
-document_sha = sha.new(document.read()).hexdigest()
+document_sha = hashlib.sha1(document.read()).hexdigest()
 print("   Document SHA1: {0}".format(document_sha))
-document.close()
 print("7. Download signature certificate from DocuSign.")
 document = envelope.get_certificate()
-document_sha = sha.new(document.read()).hexdigest()
+document_sha = hashlib.sha1(document.read()).hexdigest()
 print("   Certificate SHA1: {0}".format(document_sha))
-document.close()

--- a/demo/templates.py
+++ b/demo/templates.py
@@ -6,11 +6,16 @@ See also http://iodocs.docusign.com/APIWalkthrough/requestSignatureFromTemplate
 
 """
 from __future__ import print_function
+import hashlib
 import os
-import sha
 import uuid
 
 import pydocusign
+
+try:
+    raw_input
+except NameError:
+    raw_input = input
 
 
 def prompt(environ_key, description, default):
@@ -122,19 +127,19 @@ print("   Received envelopeId {id}".format(id=envelope.envelopeId))
 print("4. GET {account}/envelopes/{envelopeId}/recipients")
 envelope.get_recipients()
 print("   Received UserId for recipient 0: {0}".format(
-    envelope.templateRoles[0].userId))
+    envelope.recipients[0].userId))
 print("   Received UserId for recipient 1: {0}".format(
-    envelope.templateRoles[1].userId))
+    envelope.recipients[1].userId))
 
 
 # Retrieve template signing for first recipient.
 print("5. Get DocuSign Recipient View")
 signing_url = envelope.post_recipient_view(
-    routingOrder=1,
+    envelope.recipients[0],
     returnUrl=signer_return_url)
 print("   Received signing URL for recipient 0: {0}".format(signing_url))
 signing_url = envelope.post_recipient_view(
-    routingOrder=2,
+    envelope.recipients[1],
     returnUrl=signer_return_url)
 print("   Received signing URL for recipient 1: {0}".format(signing_url))
 
@@ -145,11 +150,9 @@ document_list = envelope.get_document_list()
 print("   Received document list: {0}".format(document_list))
 print("7. Download document from DocuSign.")
 document = envelope.get_document(document_list[0]['documentId'])
-document_sha = sha.new(document.read()).hexdigest()
+document_sha = hashlib.sha1(document.read()).hexdigest()
 print("   Document SHA1: {0}".format(document_sha))
-document.close()
 print("8. Download signature certificate from DocuSign.")
 document = envelope.get_certificate()
-document_sha = sha.new(document.read()).hexdigest()
+document_sha = hashlib.sha1(document.read()).hexdigest()
 print("   Certificate SHA1: {0}".format(document_sha))
-document.close()

--- a/pydocusign/models.py
+++ b/pydocusign/models.py
@@ -7,6 +7,7 @@ See https://www.docusign.com/developer-center/explore/common-terms
    CamelCase is used here to mimic DocuSign names.
 
 """
+from operator import attrgetter
 
 
 ENVELOPE_STATUS_CREATED = 'Created'
@@ -729,10 +730,7 @@ class Envelope(DocuSignObject):
             recipient.roleName = recipient_data.get('roleName', None)
             synced_recipients.append(recipient)
 
-        def cmp_recipients(a, b):
-            return cmp(a.routingOrder, b.routingOrder)
-
-        synced_recipients = sorted(synced_recipients, cmp_recipients)
+        synced_recipients.sort(key=attrgetter('routingOrder'))
         self.recipients = synced_recipients
 
     def post_recipient_view(self, recipient, returnUrl, client=None):

--- a/pydocusign/parser.py
+++ b/pydocusign/parser.py
@@ -1,5 +1,6 @@
 """Utilities to parse DocuSign callback responses."""
 from collections import OrderedDict
+from operator import itemgetter
 
 from bs4 import BeautifulSoup
 import dateutil.parser
@@ -106,7 +107,7 @@ class DocuSignCallbackParser(object):
         ... </DocuSignEnvelopeInformation>
         ... '''
         >>> parser = DocuSignCallbackParser(xml_source=xml)
-        >>> print parser.envelope_id
+        >>> print(parser.envelope_id)
         some-uuid
 
         """
@@ -213,10 +214,6 @@ class DocuSignCallbackParser(object):
                     return None
         return None
 
-    def cmp_events(self, left, right):
-        """Compare ``left`` and ``right`` events."""
-        return cmp(left['datetime'], right['datetime'])
-
     @property
     def envelope_events(self):
         """Ordered (chronological) list of events for envelope.
@@ -270,7 +267,7 @@ class DocuSignCallbackParser(object):
                     'datetime': instant,
                     'status': status,
                 })
-        events.sort(self.cmp_events)
+        events.sort(key=itemgetter('datetime'))
         return events
 
     @property
@@ -353,7 +350,7 @@ class DocuSignCallbackParser(object):
                             'recipientId': recipient_id,
                             'clientUserId': client_user_id,
                         })
-        events.sort(self.cmp_events)
+        events.sort(key=itemgetter('datetime'))
         return events
 
     @property
@@ -440,7 +437,7 @@ class DocuSignCallbackParser(object):
         for event in self.recipient_events:
             event['object'] = 'recipient'
             events.append(event)
-        events.sort(self.cmp_events)
+        events.sort(key=itemgetter('datetime'))
         return events
 
     @property
@@ -520,7 +517,7 @@ class DocuSignCallbackParser(object):
             # Register.
             recipients.append(recipient)
         # Sort by routing order.
-        recipients.sort(lambda a, b: cmp(a['RoutingOrder'], b['RoutingOrder']))
+        recipients.sort(key=itemgetter('RoutingOrder'))
         # Return OrderedDict.
         recipients = OrderedDict([(rec['ClientUserId'], rec)
                                   for rec in recipients])

--- a/pydocusign/test.py
+++ b/pydocusign/test.py
@@ -36,7 +36,7 @@ def fixtures_dir():
 def generate_notification_callback_body(
         data,
         template_url='http://diecutter.io/github/'
-                     'novapost/pydocusign/master/'
+                     'novafloss/pydocusign/master/'
                      'pydocusign/templates/callback.xml'):
     """Return custom body content to mimic DocuSign notification callbacks.
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ CLASSIFIERS = [
     'Programming Language :: Python :: 2.7',
     'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     # Add your classifiers here from
     # https://pypi.python.org/pypi?%3Aaction=list_classifiers
 ]
@@ -54,7 +55,6 @@ REQUIREMENTS = [
     'certifi',
     'python-dateutil',
     'lxml',
-    'pycurl',
     'requests',
     'setuptools',
 ]

--- a/tests.py
+++ b/tests.py
@@ -119,58 +119,6 @@ class DocuSignClientTestCase(unittest.TestCase):
                          result['loginAccounts'][0]['accountId'])
         self.assertNotEqual(docusign.account_url, '')
 
-    def test_create_envelope_from_document_request(self):
-        """Request for creating envelope for document has expected format."""
-        docusign = pydocusign.DocuSignClient()
-        docusign.login_information()
-        with open(os.path.join(pydocusign.test.fixtures_dir(), 'test.pdf'),
-                  'rb') as pdf_file:
-            envelope = pydocusign.Envelope(
-                emailSubject='This is the subject',
-                emailBlurb='This is the body',
-                status=models.ENVELOPE_STATUS_SENT,
-                documents=[
-                    pydocusign.Document(
-                        name='document.pdf',
-                        documentId=1,
-                        data=pdf_file,
-                    ),
-                ],
-                recipients=[
-                    pydocusign.Signer(
-                        email='signer@example.com',
-                        name='Zorro',
-                        recipientId=1,
-                        tabs=[
-                            pydocusign.SignHereTab(
-                                documentId=1,
-                                pageNumber=1,
-                                xPosition=100,
-                                yPosition=100,
-                            ),
-                            pydocusign.ApproveTab(
-                                documentId=1,
-                                pageNumber=1,
-                                xPosition=100,
-                                yPosition=200,
-                            ),
-                        ],
-                        accessCode='0000',
-                    ),
-                ])
-            parts = docusign._create_envelope_from_document_request(envelope)
-        self.assertTrue(parts['url'].startswith(docusign.account_url))
-        self.assertTrue(parts['url'].endswith('/envelopes'))
-        self.assertEqual(
-            parts['headers']['Content-Type'],
-            'multipart/form-data; boundary=myboundary')
-        self.assertTrue(parts['body'].strip().startswith(
-            '--myboundary\r\n'
-            'Content-Type: application/json; charset=UTF-8\r\n'
-            'Content-Disposition: form-data\r\n'
-            '\r\n'
-        ))
-
     def test_timeout(self):
         """DocuSignClient with (too small) timeout raises exception."""
         docusign = pydocusign.DocuSignClient(timeout=0.001)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,16 @@
 [tox]
-envlist = py27, flake8, sphinx, readme
+envlist =
+    py{27,33,34,35}
+    flake8,
+    sphinx,
+    readme
 
 [testenv]
+basepython =
+    py27: python2.7
+    py33: python3.3
+    py34: python3.4
+    py35: python3.5
 deps =
     coverage
     mock
@@ -11,12 +20,13 @@ passenv = DOCUSIGN_*
 commands =
     pip install -e .
     nosetests --with-doctest --no-path-adjustment --nocapture --with-coverage --cover-package=pydocusign --all-modules --rednose --verbosity=2  {posargs:pydocusign tests}
-    #python demo/embeddedsigning.py
-    #python demo/templates.py
+    python demo/embeddedsigning.py
+    python demo/templates.py
     coverage erase
     pip freeze
 
 [testenv:flake8]
+basepython = python2.7
 deps =
     flake8
 commands =
@@ -24,6 +34,7 @@ commands =
     flake8 demo
 
 [testenv:sphinx]
+basepython = python2.7
 deps =
     Sphinx
 commands =
@@ -32,6 +43,7 @@ whitelist_externals =
     make
 
 [testenv:readme]
+basepython = python2.7
 deps =
     docutils
     pygments
@@ -43,6 +55,7 @@ whitelist_externals =
     mkdir
 
 [testenv:release]
+basepython = python2.7
 deps =
     wheel
     zest.releaser


### PR DESCRIPTION
* python3 compatibility
* restore testing of `demo/embeddedsigning.py` and `demo/templates.py`
* use requests instead of pycurl for envelope creation, for python3 compatibility (and to simplify the code)
* `demo/accounts.py` anonymized
* (novapost renamed into novafloss)