### PR TITLE
Don't overwrite methods of an external object

### DIFF
--- a/pydocusign/client.py
+++ b/pydocusign/client.py
@@ -480,7 +480,6 @@ class DocuSignClient(object):
                       documentId=documentId)
         headers = self.base_headers()
         response = requests.get(url, headers=headers, stream=True)
-        setattr(response.raw, 'close', response.close)
         return response.raw
 
     def get_template(self, templateId):

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ REQUIREMENTS = [
     'certifi',
     'python-dateutil',
     'lxml',
-    'requests',
+    'requests>=2.9.0',
     'setuptools',
 ]
 ENTRY_POINTS = {}


### PR DESCRIPTION
Fixes #94 

`response.raw` is an urllib3 Response object. `response.close()` is a method on a requests Response object. I'm not sure why this was added in the first place, but this should not work.

It's possible that older versions of Requests and urllib3 had a bug around this, but using 2.9.0 and up, this line doesn't do anything useful and could be harmful.