### PR TITLE
post recipient view lookup logic

### DIFF
--- a/pydocusign/client.py
+++ b/pydocusign/client.py
@@ -450,9 +450,9 @@ class DocuSignClient(object):
         data = {
             'authenticationMethod': authenticationMethod,
             'returnUrl': returnUrl,
-            'userId': userId,
+            'clientUserId': clientUserId,
         }
-        for key in ('email', 'userName', 'clientUserId'):
+        for key in ('email', 'userName', 'userId'):
             if locals()[key] is not None:
                 data[key] = locals()[key]
         return self.post(url, data=data, expected_status_code=201)

--- a/pydocusign/client.py
+++ b/pydocusign/client.py
@@ -431,8 +431,8 @@ class DocuSignClient(object):
         return self.get(url)
 
     def post_recipient_view(self, authenticationMethod=None,
-                            clientUserId='', email='', envelopeId='',
-                            returnUrl='', userId='', userName=''):
+                            clientUserId=None, email=None, envelopeId='',
+                            returnUrl='', userId='', userName=None):
         """POST to {account}/envelopes/{envelopeId}/views/recipient.
 
         This is the method to start embedded signing for recipient.
@@ -449,13 +449,12 @@ class DocuSignClient(object):
             authenticationMethod = 'none'
         data = {
             'authenticationMethod': authenticationMethod,
-            'clientUserId': clientUserId,
-            'email': email,
-            'envelopeId': envelopeId,
             'returnUrl': returnUrl,
             'userId': userId,
-            'userName': userName,
         }
+        for key in ('email', 'userName', 'clientUserId'):
+            if locals()[key] is not None:
+                data[key] = locals()[key]
         return self.post(url, data=data, expected_status_code=201)
 
     def get_envelope_document_list(self, envelopeId):

--- a/pydocusign/client.py
+++ b/pydocusign/client.py
@@ -431,8 +431,8 @@ class DocuSignClient(object):
         return self.get(url)
 
     def post_recipient_view(self, authenticationMethod=None,
-                            clientUserId=None, email=None, envelopeId='',
-                            returnUrl='', userId='', userName=None):
+                            clientUserId='', email='', envelopeId='',
+                            returnUrl='', userId='', userName=''):
         """POST to {account}/envelopes/{envelopeId}/views/recipient.
 
         This is the method to start embedded signing for recipient.
@@ -453,7 +453,8 @@ class DocuSignClient(object):
             'clientUserId': clientUserId,
         }
         for key in ('email', 'userName', 'userId'):
-            if locals()[key] is not None:
+            # ignore empty values; they won't help with a lookup
+            if locals()[key]:
                 data[key] = locals()[key]
         return self.post(url, data=data, expected_status_code=201)
 

--- a/pydocusign/client.py
+++ b/pydocusign/client.py
@@ -449,8 +449,8 @@ class DocuSignClient(object):
             authenticationMethod = 'none'
         data = {
             'authenticationMethod': authenticationMethod,
-            'returnUrl': returnUrl,
             'clientUserId': clientUserId,
+            'returnUrl': returnUrl,
         }
         for key in ('email', 'userName', 'userId'):
             # ignore empty values; they won't help with a lookup

--- a/pydocusign/models.py
+++ b/pydocusign/models.py
@@ -484,8 +484,8 @@ class Envelope(DocuSignObject):
         """
         if client is None:
             client = self.client
-        if recipient.clientUserId:
-            lookup_kwargs = {'clientUserId': recipient.clientUserId}
+        if recipient.userId:
+            lookup_kwargs = {'userId': recipient.userId}
         else:
             lookup_kwargs = {
                 'email': recipient.email,
@@ -493,7 +493,7 @@ class Envelope(DocuSignObject):
             }
         response_data = client.post_recipient_view(
             envelopeId=self.envelopeId,
-            userId=recipient.userId,
+            clientUserId=recipient.clientUserId,
             returnUrl=returnUrl,
             **lookup_kwargs
         )

--- a/pydocusign/models.py
+++ b/pydocusign/models.py
@@ -484,13 +484,18 @@ class Envelope(DocuSignObject):
         """
         if client is None:
             client = self.client
+        if recipient.clientUserId:
+            lookup_kwargs = {'clientUserId': recipient.clientUserId}
+        else:
+            lookup_kwargs = {
+                'email': recipient.email,
+                'userName': recipient.name,
+            }
         response_data = client.post_recipient_view(
             envelopeId=self.envelopeId,
-            clientUserId=recipient.clientUserId,
-            email=recipient.email,
             userId=recipient.userId,
-            userName=recipient.name,
             returnUrl=returnUrl,
+            **lookup_kwargs
         )
         return response_data['url']
 


### PR DESCRIPTION
This will use `clientUserId`+`userId` to lookup a recipient if `userId` is available, else `clientUserId`+`email`+`userName`.  It also removes `envelopeId` from the lookup kwargs because i believe that value is ignored, and it is already used in the url endpoint path anyway.

fixes #102 