### PR TITLE
Implement JWT authentication

### DIFF
--- a/pydocusign/client.py
+++ b/pydocusign/client.py
@@ -172,8 +172,13 @@ class DocuSignClient(object):
             'Accept': 'application/json',
             'Content-Type': 'application/json',
         }
-        if self.oauth2_token:
-            headers['Authorization'] = 'Bearer ' + self.oauth2_token
+        # Use in order of preference:
+        # - OAuth jwt access token (from self._access_token)
+        # - Oauth2 password grant token (from self.oauth2_token)
+        # - Username password auth (from self.username, self.password)
+        bearer_token = self._access_token or self.oauth2_token
+        if bearer_token:
+            headers['Authorization'] = 'Bearer ' + bearer_token
 
             if sobo_email:
                 headers['X-DocuSign-Act-As-User'] = sobo_email

--- a/pydocusign/models.py
+++ b/pydocusign/models.py
@@ -396,7 +396,7 @@ class Envelope(DocuSignObject):
     attributes = ['documents', 'emailBlurb', 'emailSubject',
                   'eventNotification', 'recipients', 'templateId',
                   'templateRoles', 'status', 'envelopeId', 'userId',
-                  'enableWetSign']
+                  'enableWetSign', 'notification']
     required_attributes = ['envelopeId', 'userId']
     attribute_defaults = {
         'emailBlurb': '',
@@ -437,6 +437,8 @@ class Envelope(DocuSignObject):
         }
         if self.eventNotification:
             data['eventNotification'] = self.eventNotification.to_dict()
+        if self.notification:
+            data['notification'] = self.notification
         if self.templateId:
             data.update({
                 'templateId': self.templateId,

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,8 @@ REQUIREMENTS = [
     'lxml',
     'requests>=2.9.0',
     'setuptools',
+    'cryptography==41.0.3',
+    'PyJWT==2.8.0',
 ]
 ENTRY_POINTS = {}
 TEST_REQUIREMENTS = [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -313,3 +313,31 @@ class EnvelopeTest(unittest.TestCase):
         envelope.void('reason')
 
         client.void_envelope.assert_called_once_with('fake-envelope-id', 'reason')
+
+
+    def test_serialize_envelope_with_notification(self):
+        document = Document(
+            documentId=2,
+            name='document.pdf')
+        envelope = Envelope(
+            documents=[document],
+            emailBlurb='This is the email body',
+            emailSubject='This is the email subject',
+            status=ENVELOPE_STATUS_DRAFT,
+            notification={
+                'expirations': {
+                    'expireEnabled': True,
+                    'expireAfter': 365,
+                    'expireWarn': 5,
+                },
+            },
+        )
+        self.assertDictContainsSubset({
+            'notification': {
+                'expirations': {
+                    'expireEnabled': True,
+                    'expireAfter': 365,
+                    'expireWarn': 5,
+                },
+            },
+        }, envelope.to_dict())


### PR DESCRIPTION
Support OAuth JWT grant authentication, as defined here:
https://developers.docusign.com/platform/auth/jwt/jwt-get-token/

Client instances will need to be passed several new configuration variables to support this:
 - private_key (in textual PEM format)
 - user_id,
 - integration_key
 - audience,
 - base_url

If these values are not provided, client instances will fall back to the prior behavior, of using either OAuth2 password grant or username and password authentication.

If these values are provided, client instances for each request will request a new access token using the new `_get_access_token` method, then use that when doing the actual Docusign REST API request.